### PR TITLE
Add `seed` in `default_args` for reproducibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-
 import os
 import time
 import wandb
@@ -10,7 +9,8 @@ from transformers import (
     AutoTokenizer,
     AutoModelForCausalLM,
     TrainingArguments,
-    DataCollatorForLanguageModeling
+    DataCollatorForLanguageModeling,
+    set_seed,
 )
 from peft import LoraConfig, get_peft_model
 
@@ -168,7 +168,8 @@ class ORPO(object):
             remove_unused_columns=False,
             report_to='wandb',
             run_name=self.run_name,
-            bf16=True
+            bf16=True,
+            seed=self.args.seed,
         )
         
         data_collator = DataCollatorForLanguageModeling(tokenizer=self.tokenizer, mlm=False)
@@ -198,6 +199,9 @@ class ORPO(object):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser("ORPO")
     args = default_args(parser)
+
+    # Set the random seed for the entire pipeline
+    set_seed(args.seed)
 
     # Set WANDB configurations
     if args.wandb_entity is not None and args.wandb_project_name is not None:

--- a/src/args.py
+++ b/src/args.py
@@ -23,6 +23,7 @@ def default_args(parser):
     parser.add_argument("--prompt_max_length", default=256, type=int)
     parser.add_argument("--response_max_length", default=1024, type=int)
     parser.add_argument("--alpha", default=1.0, type=float, help="Hyperparameter for weighting L_OR")
+    parser.add_argument("--seed", default=42, type=int, help="Random seed for reproducibility.")
 
     # LoRA
     parser.add_argument("--enable_lora", action='store_true')


### PR DESCRIPTION
Hi here @jiwooya1000 @hiyouga!

## Description

This PR adds the `seed` arg in the `default_args` so that it's captured via the provided args and propagated to the `ORPOTrainer` via `seed=self.args.seed`. Besides that the `transformers.set_seed` function is also used with that seed to ensure reproducibility and that the seed is controlled globally too. This PR is mainly to be able to reproduce faithfully the runs under `./scripts` so that users can easily replicate those experiments.

Note that it defaults to 42 i.e. in case users miss to define it but want to reproduce an experiment, but we could also make it default to `None` instead which I believe is also the default in most libraries.