### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ class ORPO(object):
         else:
             self.model = AutoModelForCausalLM.from_pretrained(self.args.model_name, 
                                                               cache_dir=self.args.cache_dir,
-                                                              torch_dtype=torch.bfloat16)
+                                                              torch_dtype=torch.float16)
             
         if self.args.enable_lora:
             peft_config = LoraConfig(


### PR DESCRIPTION
bfloat16 is not supported on ampere devices so if flash attention 2 is not supported its an ampere device and dtype has to be float16