### PR TITLE
Add-log1p

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ class ORPO(object):
         else:
             pass
         self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+        self.tokenizer.padding_side = 'right'
 
         # Load Model
         print(">>> 2. Loading Model")

--- a/src/orpo_trainer.py
+++ b/src/orpo_trainer.py
@@ -78,7 +78,7 @@ class ORPOTrainer(Trainer):
                                       logits=outputs_neg.logits)
 
         # Calculate log odds
-        log_odds = (pos_prob - neg_prob) - (torch.log(1 - torch.exp(pos_prob)) - torch.log(1 - torch.exp(neg_prob)))
+        log_odds = (pos_prob - neg_prob) - (torch.log1p(-torch.exp(pos_prob)) - torch.log1p(-torch.exp(neg_prob)))
         sig_ratio = torch.nn.functional.sigmoid(log_odds)
         ratio = torch.log(sig_ratio)
         


### PR DESCRIPTION
This PR adds two things. First, it forces the tokenizers to use the right padding as there could be some models that use left padding by default. Second, we use torch.log1p as in TRL since it gives better precision for small inputs.